### PR TITLE
feat(terminal): ttyd browser-terminal (#1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,11 @@ RUN mkdir /var/run/sshd \
 # Tailscale (optioneel — alleen actief als TAILSCALE_AUTH_KEY is meegegeven)
 RUN curl -fsSL https://tailscale.com/install.sh | sh
 
+# ttyd — browser-terminal op poort 7681
+RUN curl -fsSL https://github.com/tsl0922/ttyd/releases/download/1.7.7/ttyd.x86_64 \
+        -o /usr/local/bin/ttyd \
+    && chmod +x /usr/local/bin/ttyd
+
 # SSH authorized_keys dir voor de gebruiker
 RUN mkdir -p /home/$USERNAME/.ssh \
     && chmod 700 /home/$USERNAME/.ssh \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
 
     ports:
       - "2222:22"       # SSH: verbind via  ssh claude@localhost -p 2222
+      - "7681:7681"     # ttyd: browser-terminal via http://localhost:7681
 
     volumes:
       - workspace:/workspace          # Persistente werkmap

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,6 +35,10 @@ if [ -n "$TAILSCALE_AUTH_KEY" ]; then
     echo "[entrypoint] Tailscale verbonden"
 fi
 
+# ttyd starten op poort 7681 (browser-terminal)
+echo "[entrypoint] ttyd starten op poort 7681..."
+su - claude -c "ttyd --port 7681 --writable bash" &
+
 # SSH daemon starten
 echo "[entrypoint] SSH server starten op poort 22..."
 /usr/sbin/sshd -D


### PR DESCRIPTION
## Summary
- ttyd geïnstalleerd in Docker image (poort 7681)
- entrypoint.sh start ttyd automatisch bij opstarten
- docker-compose.yml mapt poort 7681

## Gebruik
- Lokaal: http://localhost:7681
- Via Tailscale: http://claude-docker:7681

## Test plan
- [ ] Container bouwen met `docker compose up --build`
- [ ] Browser openen op http://localhost:7681
- [ ] Terminal werkt en Claude Code is bereikbaar

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)