### PR TITLE
feat(claude): bypass-modus als standaard (#3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,10 @@ COPY CLAUDE.md /home/$USERNAME/.claude/CLAUDE.md
 COPY .claude/commands/literatuur.md /home/$USERNAME/.claude/commands/literatuur.md
 RUN chown -R $USERNAME:$USERNAME /home/$USERNAME/.claude
 
+# claude alias met bypass-modus (vertrouwde container-omgeving)
+RUN echo 'alias claude="claude --dangerously-skip-permissions"' \
+        >> /home/$USERNAME/.bashrc
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 


### PR DESCRIPTION
## Summary
- Alias `claude` → `claude --dangerously-skip-permissions` toegevoegd aan `.bashrc`
- Geldt automatisch bij SSH en browser-terminal sessies

## Test plan
- [ ] Container bouwen met `docker compose up --build`
- [ ] SSH of browser-terminal openen
- [ ] `claude` typen en controleren dat er geen permissieprompts komen

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)