### PR TITLE
feat(auth): GITHUB_TOKEN automatisch configureren (#5)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,9 @@ services:
       GIT_USER_NAME: ${GIT_USER_NAME:-}
       GIT_USER_EMAIL: ${GIT_USER_EMAIL:-}
 
+      # === GitHub token (voor gh CLI en git push zonder login) ===
+      GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+
       # === Tailscale (optioneel) ===
       TAILSCALE_AUTH_KEY: ${TAILSCALE_AUTH_KEY:-}
       TAILSCALE_HOSTNAME: ${TAILSCALE_HOSTNAME:-claude-docker}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,17 @@ if [ -n "$GIT_USER_EMAIL" ]; then
     su - claude -c "git config --global user.email '${GIT_USER_EMAIL}'"
 fi
 
+# GitHub token — configureert gh CLI en git automatisch
+if [ -n "$GITHUB_TOKEN" ]; then
+    echo "[entrypoint] GitHub token instellen..."
+    # gh CLI inloggen via token
+    echo "$GITHUB_TOKEN" | su - claude -c "gh auth login --with-token"
+    # git HTTPS pushes via token (geen wachtwoordprompt)
+    su - claude -c "git config --global credential.helper store"
+    su - claude -c "git config --global url.'https://oauth2:${GITHUB_TOKEN}@github.com/'.insteadOf 'https://github.com/'"
+    echo "[entrypoint] GitHub token geconfigureerd"
+fi
+
 # Tailscale opstarten als auth key aanwezig is
 if [ -n "$TAILSCALE_AUTH_KEY" ]; then
     echo "[entrypoint] Tailscale starten..."


### PR DESCRIPTION
## Summary
- entrypoint.sh logt gh CLI automatisch in via \`GITHUB_TOKEN\`
- git wordt geconfigureerd zodat HTTPS push/pull zonder prompt werkt
- \`GITHUB_TOKEN\` toegevoegd aan docker-compose.yml

## Gebruik
Voeg toe aan \`.env\`:
\`\`\`
GITHUB_TOKEN=ghp_...
\`\`\`

## Test plan
- [ ] Token toevoegen aan \`.env\`
- [ ] Container herbouwen
- [ ] \`gh auth status\` toont ingelogd account
- [ ] \`git push\` werkt zonder wachtwoordprompt

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)