### PR TITLE
docs: sessiestart en Git-connectiviteit in CLAUDE.md (#7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,24 +4,30 @@
 
 **Dit is een Docker-omgeving. Voer dit uit aan het begin van elke nieuwe sessie:**
 
-1. Zoek bestaande projecten in `/workspace`:
+1. Haal tegelijk op:
+   - Lokale projecten in `/workspace`
+   - GitHub-repo's van de ingelogde gebruiker
    ```bash
    ls /workspace
+   gh repo list --limit 50 --json name,description,updatedAt --jq '.[] | "\(.name) — \(.description // "geen beschrijving")"'
    ```
 
-2. Stel de gebruiker de volgende vraag:
+2. Stel de gebruiker de volgende vraag, met beide lijsten:
 
-   > Ik zie de volgende projecten in `/workspace`:
-   > - `project-a`
-   > - `project-b`
+   > **Lokale projecten in `/workspace`:**
+   > 1. `project-a`
+   > 2. `project-b`
    >
-   > Wil je verder met een bestaand project, of een nieuw aanmaken?
-   > Typ een naam uit de lijst, of geef een GitHub-URL om te klonen.
+   > **Jouw GitHub-repo's (nog niet gekloned):**
+   > 3. `mijn-repo` — korte beschrijving
+   > 4. `ander-project` — korte beschrijving
+   >
+   > Kies een nummer, of typ `nieuw` om een leeg project aan te maken.
 
 3. Op basis van het antwoord:
-   - **Bestaand project** → `cd /workspace/{naam}` en ga verder
-   - **Nieuwe GitHub repo** → `git clone {url} /workspace/{naam} && cd /workspace/{naam}`
-   - **Nieuw leeg project** → maak de map aan, `git init`, koppel remote
+   - **Lokaal project gekozen** → `cd /workspace/{naam}` en ga verder
+   - **GitHub-repo gekozen** → `git clone https://github.com/{gebruiker}/{naam} /workspace/{naam} && cd /workspace/{naam}`
+   - **`nieuw`** → vraag naam en GitHub-URL, maak map aan, `git init`, koppel remote
 
 ## Git & GitHub in deze container
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,56 @@
 # Projectcontext
 
+## Sessiestart — Projectkeuze
+
+**Dit is een Docker-omgeving. Voer dit uit aan het begin van elke nieuwe sessie:**
+
+1. Zoek bestaande projecten in `/workspace`:
+   ```bash
+   ls /workspace
+   ```
+
+2. Stel de gebruiker de volgende vraag:
+
+   > Ik zie de volgende projecten in `/workspace`:
+   > - `project-a`
+   > - `project-b`
+   >
+   > Wil je verder met een bestaand project, of een nieuw aanmaken?
+   > Typ een naam uit de lijst, of geef een GitHub-URL om te klonen.
+
+3. Op basis van het antwoord:
+   - **Bestaand project** → `cd /workspace/{naam}` en ga verder
+   - **Nieuwe GitHub repo** → `git clone {url} /workspace/{naam} && cd /workspace/{naam}`
+   - **Nieuw leeg project** → maak de map aan, `git init`, koppel remote
+
+## Git & GitHub in deze container
+
+Credentials worden automatisch ingesteld via omgevingsvariabelen bij het opstarten. Je hoeft **nooit handmatig in te loggen**.
+
+### Wat is al geconfigureerd
+| Wat | Hoe |
+|-----|-----|
+| Git naam & e-mail | Via `GIT_USER_NAME` en `GIT_USER_EMAIL` in `.env` |
+| GitHub CLI (`gh`) | Via `GITHUB_TOKEN` in `.env` — automatisch ingelogd |
+| Git push/pull | Via token — geen wachtwoordprompt |
+
+### Controleren
+```bash
+gh auth status          # toont ingelogd account
+git config --global -l  # toont naam, e-mail en credential config
+```
+
+### Repo klonen
+```bash
+git clone https://github.com/gebruiker/repo /workspace/repo
+cd /workspace/repo
+```
+
+### Troubleshooting
+Als `git push` of `gh` toch om een wachtwoord vraagt, is de `GITHUB_TOKEN` waarschijnlijk verlopen of mist een scope. Vernieuw de token op **github.com → Settings → Developer settings → Personal access tokens** met scopes `repo`, `workflow` en `read:org`.
+
+---
+
 ## Taal
 
 Projectdocumentatie is in het Nederlands.


### PR DESCRIPTION
## Summary
- Claude vraagt bij elke sessiestart welk project de gebruiker wil oppakken
- Laat bestaande mappen in /workspace zien en biedt keuze: bestaand, klonen of nieuw
- Uitleg toegevoegd over automatische Git/gh configuratie via env vars
- Troubleshooting sectie voor token problemen

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)