### PR TITLE
docs: README, branch-werkwijze en gedragsregels (#9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,74 @@ Als `git push` of `gh` toch om een wachtwoord vraagt, is de `GITHUB_TOKEN` waars
 
 Projectdocumentatie is in het Nederlands.
 
+## Werkhouding bij coderen
+
+Gedragsregels om veelgemaakte LLM-fouten te beperken. Voor triviale taken: gebruik je oordeel.
+
+**Trade-off:** deze regels neigen naar zorgvuldigheid boven snelheid.
+
+### 1. Eerst denken, dan coderen
+
+**Geen aannames. Geen verborgen twijfel. Maak trade-offs zichtbaar.**
+
+Voordat je begint te bouwen:
+- Benoem aannames expliciet. Bij onzekerheid: vraag.
+- Zijn er meerdere interpretaties? Leg ze voor — kies niet stilletjes.
+- Bestaat er een eenvoudigere aanpak? Zeg dat. Geef terecht weerwoord.
+- Is iets onduidelijk? Stop. Benoem wat verwart. Vraag.
+
+### 2. Eenvoud eerst
+
+**Minimale code die het probleem oplost. Niets speculatiefs.**
+
+- Geen features buiten wat is gevraagd.
+- Geen abstracties voor eenmalige code.
+- Geen "flexibiliteit" of "configureerbaarheid" die niet is gevraagd.
+- Geen errorhandling voor scenario's die niet kunnen optreden.
+- Schrijf je 200 regels en kan het in 50? Herschrijf.
+
+Toets: "Zou een senior engineer dit overgecompliceerd vinden?" Zo ja → simplificeer.
+
+### 3. Chirurgische wijzigingen
+
+**Raak alleen aan wat moet. Ruim alleen je eigen rommel op.**
+
+Bij het bewerken van bestaande code:
+- Geen "verbeteringen" aan aangrenzende code, comments of formatting.
+- Geen refactor van wat niet stuk is.
+- Volg bestaande stijl, ook als je het zelf anders zou doen.
+- Zie je niet-gerelateerde dode code? Meld het — verwijder het niet.
+
+Als jouw wijziging iets onbruikt maakt:
+- Verwijder imports/variabelen/functies die *door jouw wijziging* onbruikt zijn.
+- Verwijder geen al bestaande dode code, tenzij gevraagd.
+
+Toets: elke gewijzigde regel moet direct te herleiden zijn naar de vraag van de gebruiker.
+
+### 4. Doelgerichte uitvoering
+
+**Definieer succescriteria. Itereer tot ze verifieerbaar groen zijn.**
+
+Vertaal taken naar verifieerbare doelen:
+- "Validatie toevoegen" → "Schrijf tests voor ongeldige invoer, maak ze groen"
+- "Bug oplossen" → "Schrijf een test die de bug reproduceert, maak hem groen"
+- "X refactoren" → "Tests groen vóór en na de wijziging"
+
+Voor taken met meerdere stappen: benoem kort het plan:
+```
+1. [Stap] → verificatie: [check]
+2. [Stap] → verificatie: [check]
+3. [Stap] → verificatie: [check]
+```
+
+Sterke succescriteria laten je zelfstandig itereren. Zwakke criteria ("zorg dat het werkt") leveren constante terugvragen op. Voor de concrete test-eerst-volgorde bij nieuwe code: zie [Testen — Werkwijze](#testen--werkwijze) verderop.
+
+---
+
+**Deze regels werken als:** minder onnodige wijzigingen in diffs, minder herschrijfwerk door overcomplicatie, en verhelderingsvragen *vóór* implementatie in plaats van na fouten.
+
+---
+
 ## Ontwikkeling & GitHub Issues — Werkwijze
 
 Elke codewijziging is gekoppeld aan een GitHub issue. Dit is de vaste werkwijze:
@@ -81,27 +149,35 @@ gh issue create --title "..." --body "..." --label "..."
 | `research` | Onderzoek of verkenning, nog geen code |
 | `chore` | Onderhoud, dependencies, CI/CD |
 
-### 2. Branch + worktree per issue
-Werk op een branch die verwijst naar het issue, en gebruik een **worktree** zodat `main` onaangeraakt blijft en er parallel aan meerdere issues gewerkt kan worden.
+### 2. Branch per issue
+Werk per issue op een aparte feature-branch zodat `main` onaangeraakt blijft en er parallel aan meerdere issues gewerkt kan worden.
 
 **Stappen:**
-1. Maak een worktree aan via de ingebouwde `EnterWorktree`-tool:
+1. Zorg dat `main` up-to-date is en maak een nieuwe branch aan:
+   ```bash
+   git checkout main
+   git pull
+   git checkout -b issue-42-korte-beschrijving
    ```
-   EnterWorktree(name="issue-42-korte-beschrijving")
+2. Werk op die branch — commits, bewerkingen en pushes gebeuren allemaal hier.
+3. Push de branch en open een Pull Request:
+   ```bash
+   git push -u origin issue-42-korte-beschrijving
+   gh pr create --fill
    ```
-   Dit maakt automatisch een nieuwe branch aan en schakelt de hele Claude Code-sessie om naar de worktree-directory (`.claude/worktrees/`).
-2. Vanaf dat moment werk je in de worktree — alle bestanden, commits en bewerkingen vinden daar plaats.
-3. Na afronding (PR gemerged): **verwijder altijd de worktree** via `ExitWorktree(action="remove", discard_changes=true)`.
-   De code zit veilig in `main` na de merge — de worktree is dan overbodig.
-   Wil je later terugkomen (werk nog niet af): `ExitWorktree(action="keep")`.
+4. Na merge: schakel terug naar `main`, trek de wijzigingen op en verwijder de branch lokaal:
+   ```bash
+   git checkout main
+   git pull
+   git branch -d issue-42-korte-beschrijving
+   ```
 
-**Naamconventie worktree/branch:** `issue-{nummer}-{korte-beschrijving}`
+**Naamconventie branch:** `issue-{nummer}-{korte-beschrijving}`
 
 **Belangrijk:**
-- Werk **nooit** direct op `main` — altijd via een worktree
-- Elke nieuwe programmeeropdracht → nieuw issue → nieuwe worktree
-- Na merge → worktree verwijderen (opruimen)
-- Bij het openen van een bestaande worktree: gebruik `EnterWorktree` om de sessie naar die directory te verplaatsen
+- Werk **nooit** direct op `main` — altijd via een feature-branch
+- Elke nieuwe programmeeropdracht → nieuw issue → nieuwe branch
+- Na merge → lokale branch opruimen met `git branch -d`
 
 ### 3. Conventional Commits
 Elk commit-bericht volgt de [Conventional Commits](https://www.conventionalcommits.org/) standaard:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,236 @@
+# Claude Code Docker
+
+Een persoonlijke, herbruikbare Docker-omgeving voor [Claude Code](https://docs.claude.com/en/docs/claude-code) met Git, GitHub CLI en optioneel Tailscale al voor je geregeld.
+
+---
+
+## Dagelijks gebruik
+
+> Deze sectie ga je het vaakst gebruiken: container starten en aan een project werken. De [eerste-keer setup](#eerste-keer-setup) staat verderop in deze README — alleen nodig op een nieuwe machine.
+
+### 1. Container starten (vanaf je host)
+
+Open een terminal in deze repo en start de container (als die nog niet draait):
+
+```bash
+docker compose up -d
+```
+
+Niets te doen als hij al draait — `restart: unless-stopped` houdt hem aan.
+
+### 2. In de container terechtkomen
+
+Twee makkelijke opties — kies wat je prettig vindt:
+
+**Browser-terminal** (geen client nodig):
+
+```
+http://localhost:7681
+```
+
+**SSH** (vanaf dezelfde host-terminal):
+
+```bash
+ssh claude@localhost -p 2222
+```
+
+### 3. Claude Code starten
+
+Eenmaal binnen:
+
+```bash
+claude
+```
+
+Claude vraagt automatisch welk project je wilt openen en laat zowel je **lokale projecten in `/workspace`** als je **GitHub-repo's** zien:
+
+> **Lokale projecten in `/workspace`:**
+> 1. `project-a`
+> 2. `project-b`
+>
+> **Jouw GitHub-repo's (nog niet gekloond):**
+> 3. `mijn-repo` — korte beschrijving
+> 4. `ander-project` — korte beschrijving
+>
+> Kies een nummer, of typ `nieuw` om een leeg project aan te maken.
+
+### 4a. Verder aan een bestaand GitHub-project
+
+- **Staat het al in `/workspace`?** Kies het nummer onder *Lokale projecten*. Claude doet `cd /workspace/<naam>` en gaat verder. De project-`CLAUDE.md` (als die er is) wordt automatisch geladen.
+- **Staat het nog niet in de container?** Kies het nummer onder *Jouw GitHub-repo's*. Claude kloont automatisch via `gh` — geen login nodig — en springt erin:
+  ```bash
+  git clone https://github.com/<jij>/<repo> /workspace/<repo>
+  cd /workspace/<repo>
+  ```
+
+Vanaf dat moment werk je volgens [`CLAUDE.md`](./CLAUDE.md): issue eerst, feature-branch, conventional commits, PR naar `main`.
+
+### 4b. Een nieuw project starten
+
+Typ `nieuw` bij de projectkeuze. Claude vraagt:
+
+- de **projectnaam** (wordt `/workspace/<naam>`)
+- optioneel een **GitHub-URL** voor een lege repo die je vooraf hebt aangemaakt
+
+Daarna maakt Claude de map aan, doet `git init`, koppelt de remote en je kunt aan de slag. Vraag eventueel direct `/init` aan Claude — dan schrijft die meteen een project-`CLAUDE.md` op basis van wat er al is.
+
+---
+
+## Hoe `CLAUDE.md` werkt
+
+Claude Code stapelt `CLAUDE.md`-bestanden automatisch:
+
+| Locatie | Wat staat erin | Wanneer geladen |
+|---------|----------------|-----------------|
+| `~/.claude/CLAUDE.md` (globaal in container) | De `CLAUDE.md` van *deze* repo — projectkeuze, issues, branches, conventional commits, testen | **Altijd** — geldt voor elk project |
+| `/workspace/<project>/CLAUDE.md` | Projectspecifieke afspraken, architectuur, dependencies | Automatisch wanneer je `cd /workspace/<project>` doet en `claude` start |
+
+Beide gelden tegelijk. De globale werkwijze blijft overeind, projectregels komen erbovenop.
+
+---
+
+## Eerste-keer setup
+
+Alleen nodig de eerste keer op een machine (deze of een andere).
+
+### Vereisten
+
+- Docker Desktop (Windows/Mac) of Docker Engine + `docker compose` (Linux)
+- Een Anthropic API key — [console.anthropic.com](https://console.anthropic.com)
+- Optioneel: een GitHub Personal Access Token met scopes `repo`, `workflow`, `read:org`
+
+### 1. Repo klonen
+
+```bash
+git clone https://github.com/gvanhassel/claude-docker
+cd claude-docker
+```
+
+### 2. `.env` aanmaken
+
+Maak `.env` in de repo-root (wordt door `.gitignore` uitgesloten):
+
+```env
+# === VERPLICHT ===
+ANTHROPIC_API_KEY=sk-ant-...
+
+# === SSH toegang (kies wachtwoord óf publieke sleutel, of beide) ===
+SSH_PASSWORD=kies_een_sterk_wachtwoord
+SSH_PUBLIC_KEY=ssh-ed25519 AAAA... jouw@email
+
+# === Git identiteit ===
+GIT_USER_NAME=jouw-github-naam
+GIT_USER_EMAIL=jij@example.com
+
+# === GitHub token (gh CLI + git push zonder prompt) ===
+GITHUB_TOKEN=ghp_...
+
+# === Tailscale (optioneel — laat leeg om te skippen) ===
+TAILSCALE_AUTH_KEY=tskey-auth-...
+TAILSCALE_HOSTNAME=claude-docker
+```
+
+### 3. Container builden en starten
+
+```bash
+docker compose up -d --build
+```
+
+De eerste build duurt een paar minuten. Daarna draait alles in de achtergrond en herstart automatisch bij een reboot.
+
+Daarna ben je klaar — terug naar [Dagelijks gebruik](#dagelijks-gebruik).
+
+---
+
+## Wat zit erin
+
+- **Ubuntu 24.04** + Node.js 22 + Claude Code (globaal geïnstalleerd)
+- **GitHub CLI (`gh`)** — automatisch ingelogd via `GITHUB_TOKEN`
+- **Git** — naam, e-mail en token-credentials worden bij start ingesteld
+- **SSH-server** op poort `2222` (host) → `22` (container)
+- **ttyd** browser-terminal op poort `7681`
+- **Tailscale** (optioneel) — bereik de container vanaf elk apparaat in je tailnet
+- **Persistente `/workspace`** — blijft behouden tussen container-restarts en rebuilds
+- **Globale `CLAUDE.md`** in `~/.claude/CLAUDE.md` — jouw werkwijze geldt voor *alle* projecten
+
+---
+
+## Vanaf een andere machine bereiken (Tailscale)
+
+Heb je `TAILSCALE_AUTH_KEY` ingesteld? Dan is de container ook van onderweg bereikbaar:
+
+```bash
+ssh claude@claude-docker
+```
+
+Werkt vanaf elk apparaat dat in jouw tailnet zit.
+
+---
+
+## Persistentie
+
+| Wat | Waar | Blijft behouden bij... |
+|-----|------|------------------------|
+| Code en projecten | `/workspace` (volume `workspace`) | restart, rebuild, host-reboot |
+| Tailscale-state | `/var/lib/tailscale` (volume `tailscale-state`) | restart, rebuild |
+| Globale `~/.claude` | In de image | restart (komt vers uit Dockerfile bij rebuild) |
+
+Volledig opschonen — **verwijdert al je projecten in `/workspace`**:
+
+```bash
+docker compose down -v
+```
+
+---
+
+## Troubleshooting
+
+### Logs bekijken
+
+```bash
+docker compose ps
+docker compose logs -f claude
+```
+
+### Controleren in de container
+
+```bash
+gh auth status            # toont ingelogd account
+git config --global -l    # toont naam, e-mail, credential helper
+```
+
+### `git push` of `gh` vraagt om wachtwoord
+
+`GITHUB_TOKEN` is verlopen of mist een scope. Vernieuw op **github.com → Settings → Developer settings → Personal access tokens** met scopes `repo`, `workflow`, `read:org`. Pas `.env` aan en herstart:
+
+```bash
+docker compose up -d --force-recreate
+```
+
+### `.env` aangepast — hoe activeer ik de wijzigingen?
+
+Environment-variabelen worden alleen bij start gelezen:
+
+```bash
+docker compose up -d --force-recreate
+```
+
+### Image opnieuw builden (na Dockerfile-wijziging)
+
+```bash
+docker compose up -d --build
+```
+
+---
+
+## Werkwijze in projecten
+
+Zodra je in een project zit gelden de regels uit [`CLAUDE.md`](./CLAUDE.md):
+
+- Elke wijziging hoort bij een GitHub issue
+- Werk op een feature-branch, nooit direct op `main`
+- Conventional Commits voor commit-berichten
+- Pytest voor unit tests, `tests/integration/` voor integratietests
+- PR met groene CI vóór merge naar `main`
+
+Zie `CLAUDE.md` voor de volledige werkwijze.


### PR DESCRIPTION
## Samenvatting
- **README.md** toegevoegd met dagelijks gebruik bovenaan (container starten, in container komen, project kiezen) en eerste-keer setup eronder
- **CLAUDE.md** — \"Branch + worktree per issue\" vervangen door \"Branch per issue\" (git checkout -b → push → PR → branch -d na merge)
- **CLAUDE.md** — nieuwe sectie *Werkhouding bij coderen*: denken-voor-coderen, eenvoud eerst, chirurgische wijzigingen, doelgerichte uitvoering

Closes #9

## Test plan
- [x] README leesbaar in GitHub-preview
- [x] CLAUDE.md interne anchor-link naar Testen-werkwijze klopt
- [x] Geen verwijzingen meer naar EnterWorktree/ExitWorktree